### PR TITLE
ISSUE-92 Template updated to have the sso_region key filled dynamically

### DIFF
--- a/template/config/common.tfvars.template
+++ b/template/config/common.tfvars.template
@@ -30,4 +30,4 @@ vault_token = "s.XXXXXXXXXXXXXXXXXXXXXX.Apshc"
 # AWS SSO
 sso_enabled   = false
 sso_start_url = "https://bbleverage.awsapps.com/start"
-sso_region    = "us-east-1"
+sso_region    = "{{ primary_region | default("us-east-1") }}"


### PR DESCRIPTION
## What?
* Template updated so sso_region key is filled dynamically.

## Why?
* It does not make sense to have two keys with region values and only one being updated dynamically
* this also ensures consistency

## References
changed this
```
sso_region    = "us-east-1"
```

to this
```
sso_region    = "{{ primary_region | default("us-east-1") }}"
```

