### PR TITLE
Enhancement | Removed shared_credentials_file key from aws provider (ISSUE-92 from Leverage)

### DIFF
--- a/template/management/global/base-identities/config.tf
+++ b/template/management/global/base-identities/config.tf
@@ -4,7 +4,6 @@
 provider "aws" {
   region                  = var.region
   profile                 = var.profile
-  shared_credentials_file = "~/.aws/${var.project}/config"
 }
 
 #=============================#

--- a/template/management/global/organizations/config.tf
+++ b/template/management/global/organizations/config.tf
@@ -4,7 +4,6 @@
 provider "aws" {
   region                  = var.region
   profile                 = var.profile
-  shared_credentials_file = "~/.aws/${var.project}/config"
 }
 
 #=============================#

--- a/template/management/global/sso/config.tf
+++ b/template/management/global/sso/config.tf
@@ -4,7 +4,6 @@
 provider "aws" {
   region                  = var.region
   profile                 = var.profile
-  shared_credentials_file = "~/.aws/${var.project}/config"
 }
 
 #=============================#

--- a/template/management/primary_region/base-tf-backend/config.tf
+++ b/template/management/primary_region/base-tf-backend/config.tf
@@ -5,14 +5,12 @@ provider "aws" {
   alias                   = "main_region"
   region                  = var.region
   profile                 = var.profile
-  shared_credentials_file = "~/.aws/${var.project}/config"
 }
 
 provider "aws" {
   alias                   = "secondary_region"
   region                  = var.region_secondary
   profile                 = var.profile
-  shared_credentials_file = "~/.aws/${var.project}/config"
 }
 
 terraform {

--- a/template/management/primary_region/security-base/config.tf
+++ b/template/management/primary_region/security-base/config.tf
@@ -4,7 +4,6 @@
 provider "aws" {
   region                  = var.region
   profile                 = var.profile
-  shared_credentials_file = "~/.aws/${var.project}/config"
 }
 
 #=============================#

--- a/template/security/global/base-identities/config.tf
+++ b/template/security/global/base-identities/config.tf
@@ -4,7 +4,6 @@
 provider "aws" {
   region                  = var.region
   profile                 = var.profile
-  shared_credentials_file = "~/.aws/${var.project}/config"
 }
 
 #=============================#

--- a/template/security/primary_region/base-tf-backend/config.tf
+++ b/template/security/primary_region/base-tf-backend/config.tf
@@ -5,14 +5,12 @@ provider "aws" {
   alias                   = "main_region"
   region                  = var.region
   profile                 = var.profile
-  shared_credentials_file = "~/.aws/${var.project}/config"
 }
 
 provider "aws" {
   alias                   = "secondary_region"
   region                  = var.region_secondary
   profile                 = var.profile
-  shared_credentials_file = "~/.aws/${var.project}/config"
 }
 
 terraform {

--- a/template/security/primary_region/security-base/config.tf
+++ b/template/security/primary_region/security-base/config.tf
@@ -4,7 +4,6 @@
 provider "aws" {
   region                  = var.region
   profile                 = var.profile
-  shared_credentials_file = "~/.aws/${var.project}/config"
 }
 
 #=============================#

--- a/template/shared/global/base-identities/config.tf
+++ b/template/shared/global/base-identities/config.tf
@@ -4,7 +4,6 @@
 provider "aws" {
   region                  = var.region
   profile                 = var.profile
-  shared_credentials_file = "~/.aws/${var.project}/config"
 }
 
 #=============================#

--- a/template/shared/primary_region/base-network/config.tf
+++ b/template/shared/primary_region/base-network/config.tf
@@ -4,7 +4,6 @@
 provider "aws" {
   region                  = var.region
   profile                 = var.profile
-  shared_credentials_file = "~/.aws/${var.project}/config"
 }
 
 #=============================#

--- a/template/shared/primary_region/base-tf-backend/config.tf
+++ b/template/shared/primary_region/base-tf-backend/config.tf
@@ -5,14 +5,12 @@ provider "aws" {
   alias                   = "main_region"
   region                  = var.region
   profile                 = var.profile
-  shared_credentials_file = "~/.aws/${var.project}/config"
 }
 
 provider "aws" {
   alias                   = "secondary_region"
   region                  = var.region_secondary
   profile                 = var.profile
-  shared_credentials_file = "~/.aws/${var.project}/config"
 }
 
 terraform {

--- a/template/shared/primary_region/security-base/config.tf
+++ b/template/shared/primary_region/security-base/config.tf
@@ -4,7 +4,6 @@
 provider "aws" {
   region                  = var.region
   profile                 = var.profile
-  shared_credentials_file = "~/.aws/${var.project}/config"
 }
 
 #=============================#


### PR DESCRIPTION
## What?
* the key shared_credentials_file was removed from AWS provider in all the templates.

## Why?
* not needed anymore

## References
n/a
