### PR TITLE
Enhancement | Enable default-NACL and Disable dedicated-NACL by default

### DIFF
--- a/template/shared/primary_region/base-network/variables.tf
+++ b/template/shared/primary_region/base-network/variables.tf
@@ -160,17 +160,17 @@ variable "enable_kms_endpoint_private_dns" {
 variable "manage_default_network_acl" {
   description = "Manage default Network ACL"
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "public_dedicated_network_acl" {
   description = "Manage default Network ACL"
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "private_dedicated_network_acl" {
   description = "Manage default Network ACL"
   type        = bool
-  default     = true
+  default     = false
 }


### PR DESCRIPTION
## What?
* Ensure that restrictive Network ACLs (NACLs) are disabled by default.
* In the default configuration, Dedicated-NACLs will be disabled, variables setup:
```
  manage_default_network_acl    = true
  public_dedicated_network_acl  = false // use dedicated network ACL for the public subnets.
  private_dedicated_network_acl = false // use dedicated network ACL for the private subnets.
```

## Why?
* Prevent potential complications, streamline user experience, and ensure that the use of NACLs is only when explicitly required and approved.
* Provide a safer and more user-friendly default setting by having restrictive NACLs disabled.

## References
* Closes a GitHub issue #36 

