### PR TITLE
feat(SYNC-MODULES): Add modules syncronization with le-tf-infra-aws repo

### DIFF
--- a/.github/workflows/sync-modules.yml
+++ b/.github/workflows/sync-modules.yml
@@ -1,0 +1,83 @@
+name: Synchronize Module Versions
+on:
+  # schedule every sunday at 00:00
+  schedule:
+    - cron: "0 0 * * 0"
+  workflow_dispatch:
+env:
+  SSO_MODULE: "management/global/sso/account_assignments.tf"
+  BACKEND_MODULE: "base-tf-backend/main.tf"
+  SECURITY_BASE_MODULE: "security-base/account.tf"
+  BASE_NETWORK_MODULE: "base-network/network.tf"
+  BASE_NETWORK_FLOW_MODULE_REFARCH: "base-network/vpc_flow_logs.tf"
+  BASE_NETWORK_FLOW_MODULE: "base-network/network_vpc_flow_logs.tf"
+jobs:
+    synchronize_modules: 
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+              with:
+                path: le-tf-infra-aws-template
+            - name: Checkout le-tf-infra-aws repo 
+              uses: actions/checkout@v4
+              with:
+                repository: "binbashar/le-tf-infra-aws"
+                path: le-tf-infra-aws
+            - name: SSO Module on Management account
+              run: |
+                cd le-tf-infra-aws-template
+                chmod +x sync_modules.sh
+                ./sync_modules.sh ../le-tf-infra-aws/$SSO_MODULE template/$SSO_MODULE 
+            - name: Backend Module on Management account
+              run: |
+                cd le-tf-infra-aws-template
+                chmod +x sync_modules.sh
+                ./sync_modules.sh ../le-tf-infra-aws/management/us-east-1/$BACKEND_MODULE template/management/primary_region/$BACKEND_MODULE
+            - name: Backend Module on Security account
+              run: |
+                cd le-tf-infra-aws-template
+                chmod +x sync_modules.sh
+                ./sync_modules.sh ../le-tf-infra-aws/security/us-east-1/$BACKEND_MODULE template/security/primary_region/$BACKEND_MODULE
+            - name: Backend Module on Shared account
+              run: |
+                cd le-tf-infra-aws-template
+                chmod +x sync_modules.sh
+                ./sync_modules.sh ../le-tf-infra-aws/shared/us-east-1/$BACKEND_MODULE template/shared/primary_region/$BACKEND_MODULE
+            - name: Security Base Module on Security account
+              run: |
+                cd le-tf-infra-aws-template
+                chmod +x sync_modules.sh
+                ./sync_modules.sh ../le-tf-infra-aws/security/us-east-1/$SECURITY_BASE_MODULE template/security/primary_region/$SECURITY_BASE_MODULE
+            - name: Base Network Module on Shared account
+              run: |
+                cd le-tf-infra-aws-template
+                chmod +x sync_modules.sh
+                ./sync_modules.sh ../le-tf-infra-aws/shared/us-east-1/$BASE_NETWORK_MODULE template/shared/primary_region/$BASE_NETWORK_MODULE
+            - name: Base Network Flow Module on Shared account
+              run: |
+                cd le-tf-infra-aws-template
+                chmod +x sync_modules.sh
+                ./sync_modules.sh ../le-tf-infra-aws/shared/us-east-1/$BASE_NETWORK_FLOW_MODULE_REFARCH template/shared/primary_region/$BASE_NETWORK_FLOW_MODULE
+            - name: Create Pull Request
+              uses: peter-evans/create-pull-request@v7
+              with:
+                commit-message: "chore(deps): Synchonize module versions with le-tf-infra-aws repository"
+                title: "chore(deps): Synchonize module versions with le-tf-infra-aws repository"
+                path: le-tf-infra-aws-template
+                body: |
+                  ## What?
+                  * Syncronize terraform modules versions with the le-tf-infra-aws repository.
+                  
+                  ## Why?
+                  * To keep terraform modules versions up to date with the le-tf-infra-aws repository.
+                  
+                  ## References
+                  * [le-tf-infra-aws](https://github.com/binbashar/le-tf-infra-aws)
+                  * [documentation](https://binbash.atlassian.net/wiki/spaces/BDPS/pages/2710077441/Synchronizing+Terraform+Module+Versions+Templates+with+Ref+Arch)
+                branch: "sync-modules"
+                branch-suffix: timestamp
+                base: master
+                labels: |
+                  enhancement
+                  patch

--- a/sync_modules.sh
+++ b/sync_modules.sh
@@ -1,0 +1,66 @@
+#! /bin/bash
+
+#################################################################################################################################################
+# This script is used to compare module versions and update the template file if the versions do not match                                      #                                     
+# Usage: ./sync_modules.sh <infra_file> <template_file>                                                                                         #                             
+# Example: ./sync_modules.sh le-tf-infra-aws/management/global/sso/account_assignments.tf template/management/global/sso/account_assignments.tf #
+#################################################################################################################################################
+
+# management/global/sso/account_assignments.tf
+# management/primary_region/base-tf-backend/main.tf
+# security/primary_region/base-tf-backend/main.tf
+# security/primary_region/security-base/account.tf
+# shared/primary_region/base-network/network_vpc_flow_logs.tf
+# shared/primary_region/base-network/network.tf
+# shared/primary_region/base-tf-backend/main.tf
+
+# Check if the number of arguments is correct
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 <infra_file> <template_file>"
+  exit 1
+fi
+
+# print message that initiate the comparison
+echo -e "Initiating comparison:\nInfra file: $1\nTemplate file: $2\n"
+
+# It should comtains the path of the infra file and the template file
+INFRA_FILE=$1
+TEMPLATE_FILE=$2
+
+if [ -z $TEMPLATE_FILE ]; then
+  echo "Template file does not exist"
+  exit 1
+fi
+
+if [ -z $INFRA_FILE ]; then
+  echo "Infra file does not exist"
+  exit 1
+fi
+
+TEMPLATE_VERSION=$(cat $TEMPLATE_FILE | grep -oP 'ref=\K[^"]*' | head -n 1)
+INFRA_VERSION=$(cat $INFRA_FILE | grep -oP 'ref=\K[^"]*' | head -n 1)
+
+
+if [ -z $INFRA_VERSION ]; then
+  echo "Infra Version value taken from the files is empty"
+  exit 1
+fi
+
+if [ -z $TEMPLATE_VERSION ]; then
+  echo "Template Version value taken from the files is empty"
+  exit 1
+fi
+
+echo "Current Template Version: $TEMPLATE_VERSION"
+echo "Current Infra Version: $INFRA_VERSION"
+
+if [ "$TEMPLATE_VERSION" == "$INFRA_VERSION" ]; then
+  echo "Versions match, no need to update"
+  exit 0
+else
+  echo "Versions do not match, updating on template repository"
+  sed -i "s/ref=$TEMPLATE_VERSION/ref=$INFRA_VERSION/g" $TEMPLATE_FILE
+  git add $TEMPLATE_FILE
+  echo "Updated the version in the template repository file to $INFRA_VERSION"
+  exit 0
+fi


### PR DESCRIPTION
## What?
 * Syncronize terraform modules versions with the le-tf-infra-aws repository.

## Why?
* To keep terraform modules versions up to date with the le-tf-infra-aws repository.

## References
* [le-tf-infra-aws](https://github.com/binbashar/le-tf-infra-aws)
* [Enhancement | Sync template with Ref Arch 11/24](https://github.com/binbashar/le-tf-infra-aws-template/issues/45)

