### PR TITLE
Remove unused vault variables

### DIFF
--- a/template/config/common-variables.tf
+++ b/template/config/common-variables.tf
@@ -71,16 +71,6 @@ variable "accounts" {
   description = "Accounts descriptions"
 }
 
-variable "vault_address" {
-  type        = string
-  description = "Vault Address"
-}
-
-variable "vault_token" {
-  type        = string
-  description = "Vault Token"
-}
-
 variable "management_account_id" {
   type        = string
   description = "Account: Management"


### PR DESCRIPTION
## What?
Removing unused vault variables

## Why?
The landing zone does not make use of them

## References
`closes #41`

